### PR TITLE
chore: fix inconsistency between schema field property and comment

### DIFF
--- a/base/pkg/kusion_models/kube/frontend/common/metadata.k
+++ b/base/pkg/kusion_models/kube/frontend/common/metadata.k
@@ -4,7 +4,7 @@ schema Metadata:
 
     Attributes
     ----------
-    name: str, default is Undefined, required.
+    name: str, default is Undefined, optional.
         The name of the resource.
         Name must be unique within a namespace. It's required when creating
         resources, although some resources may allow a client to request the

--- a/base/pkg/kusion_models/kube/frontend/container/container.k
+++ b/base/pkg/kusion_models/kube/frontend/container/container.k
@@ -38,6 +38,12 @@ schema Main:
     startupProbe: p.Probe, default is Undefined, optional.
         A Container-level attribute.
         The probe to indicates that the Pod has successfully initialized.
+    lifecycle: lc.Lifecycle, default is Undefined, optional
+        Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+    securityContext: {str:any}, default is Undefined, optional
+        SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    workingDir: str, default is Undefined, optional
+        Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
 
     Examples
     --------

--- a/base/pkg/kusion_models/kube/frontend/container/port/container_port.k
+++ b/base/pkg/kusion_models/kube/frontend/container/port/container_port.k
@@ -10,7 +10,7 @@ schema ContainerPort:
     protocol: "TCP" | "UDP" | "SCTP", default is "TCP", required.
         A Container-level attribute.
         The protocol for port. Must be UDP, TCP or SCTP. Default is TCP.
-    containerPort: int, default is Undefined, optional.
+    containerPort: int, default is Undefined, required.
         A Container-level attribute.
         The number of port to expose on the container's IP address.
 

--- a/base/pkg/kusion_models/kube/frontend/container/probe/probe.k
+++ b/base/pkg/kusion_models/kube/frontend/container/probe/probe.k
@@ -55,7 +55,7 @@ schema Exec:
 
     Attributes
     ----------
-    command: str, default is Undefined, required.
+    command: [str], default is Undefined, required.
         A Container-level attribute.
         The command line to execute inside the container.
     """

--- a/base/pkg/kusion_models/kube/frontend/ingress/ingress.k
+++ b/base/pkg/kusion_models/kube/frontend/ingress/ingress.k
@@ -1,5 +1,5 @@
 import base.pkg.kusion_models.kube.frontend.common
-import base.pkg.kusion_kubernetes.api.networking.v1 as networking_v1
+import base.pkg.kusion_kubernetes.api.networking.v1 as networkingv1
 
 schema Ingress(common.Metadata):
     """Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. 
@@ -7,38 +7,9 @@ schema Ingress(common.Metadata):
 
     Attributes
     ----------
-    name: str
-        The name of the resource.
-        Name must be unique within a namespace. It's required when creating
-        resources, although some resources may allow a client to request the
-        generation of an appropriate name automatically.
-        Name is primarily intended for creation idempotence and configuration
-        definition. Cannot be updated. More info:
-        http://kubernetes.io/docs/user-guide/identifiers#names
-        Required.
-    labels: {str:str}
-        Labels is a map of string keys and values that can be used to
-        organize and categorize (scope and select) objects.
-        May match selectors of replication controllers and services.
-        More info: http://kubernetes.io/docs/user-guide/labels
-        Optional.
-    annotations: {str:str}
-        Annotations is an unstructured key value map stored with a
-        resource that may be set by external tools to store and retrieve
-        arbitrary metadata. They are not queryable and should be preserved
-        when modifying objects.
-        More info: http://kubernetes.io/docs/user-guide/annotations
-        Optional.
-    namespace: str
-        Namespaces are intended for use in environments with many users spread
-        across multiple teams, or projects.
-        For clusters with a few to tens of users, you should not need to create
-        or think about namespaces at all. Start using namespaces when you need the features they provide.
-        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-        Optional.
-    rules: [networking_v1beta1.IngressRule]
+    rules: [networkingv1.IngressRule], default is Undefined, optional
         A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
-    tls: [IngressTLS], default is Undefined, optional
+    tls: [networkingv1.IngressTLS], default is Undefined, optional
         TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
 
     Examples
@@ -62,11 +33,11 @@ schema Ingress(common.Metadata):
         ]
         tls = [
             {
-              hosts = ["your-domain.com"]
-              secretName = "example-ingress-tls"
+                hosts = ["your-domain.com"]
+                secretName = "example-ingress-tls"
             }
         ]
     }
     """
-    rules?: [networking_v1.IngressRule]
-    tls?: [networking_v1.IngressTLS]
+    rules?: [networkingv1.IngressRule]
+    tls?: [networkingv1.IngressTLS]

--- a/base/pkg/kusion_models/kube/frontend/job.k
+++ b/base/pkg/kusion_models/kube/frontend/job.k
@@ -18,7 +18,7 @@ schema Job:
         before the system tries to terminate it; value must be positive integer
     backoffLimit: int, default is 6, optional.
         Specifies the number of retries before marking this job failed. Defaults to 6
-    completionMode: str, default is Undefined, optional
+    completionMode: "NonIndexed" | "Indexed", default is NonIndexed, optional
         CompletionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.
     completions: int, default is Undefined, optional.
         Specifies the desired number of successfully finished pods the job should be run with.
@@ -33,7 +33,7 @@ schema Job:
         Suspend specifies whether the Job controller should create Pods or not.
     ttlSecondsAfterFinished: int, default is Undefined, optional.
         ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed).
-    selector: apis.LabelSelector, default is Undefined, optional.
+    selector: {str:str}, default is Undefined, optional.
         A label query over pods that should match the pod count.
         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
     podMetadata: apis.ObjectMeta, default is Undefined, optional.
@@ -44,20 +44,20 @@ schema Job:
     annotations: {str:str}, default is Undefined, optional.
         Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.
         More info: http://kubernetes.io/docs/user-guide/annotations
-    restartPolicy: str, default is Never, optional.
+    restartPolicy: "Never" | "OnFailure", default is Never, optional.
         Restart policy for all containers within the pod. One of Always, OnFailure, Never.
         Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
     mainContainer: container.Main, default is Undefined, required.
         MainContainer describes the main container configuration that is expected to be run on the host.
-    image: str, default is Undefined, optional.
-        Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-    schedulingStrategy: strategy.SchedulingStrategy, default is Undefined, required.
+    image: str, default is Undefined, required.
+        Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+    schedulingStrategy: strategy.SchedulingStrategy, default is Undefined, optional.
         SchedulingStrategy represents scheduling strategy.
     sidecarContainers: [s.Sidecar], default is Undefined, optional.
         SidecarContainers describes the list of sidecar container configuration that is expected to be run on the host.
     initContainers: [s.Sidecar], default is Undefined, optional.
         InitContainers describes the list of sidecar container configuration that is expected to be run on the host.
-    needNamespace: bool，default is True, optional.
+    needNamespace: bool, default is True, optional.
         NeedNamespace mark server is namespace scoped or not.
     volumes: [volume.Volume], default is Undefined, optional.
         Volumes represents a named volume and corresponding mounts in containers.

--- a/base/pkg/kusion_models/kube/frontend/rbac/cluster_role.k
+++ b/base/pkg/kusion_models/kube/frontend/rbac/cluster_role.k
@@ -4,9 +4,9 @@ import base.pkg.kusion_models.kube.mixins
 
 schema ClusterRole(common.Metadata):
     """
-    rules : [PolicyRule], default is Undefined, optional
+    rules: [PolicyRule], default is Undefined, optional
         Rules holds all the PolicyRules for this ClusterRole
-    aggregationRule : AggregationRule, default is Undefined, optional
+    aggregationRule: AggregationRule, default is Undefined, optional
         AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
     """
     mixin [

--- a/base/pkg/kusion_models/kube/frontend/rbac/cluster_role_binding.k
+++ b/base/pkg/kusion_models/kube/frontend/rbac/cluster_role_binding.k
@@ -4,9 +4,9 @@ import base.pkg.kusion_models.kube.mixins
 
 schema ClusterRoleBinding(common.Metadata):
     """
-    subjects : [Subject], default is Undefined, optional
+    subjects: [Subject], default is Undefined, optional
         Subjects holds references to the objects the role applies to.
-    roleRef : ClusterRole, default is Undefined, required
+    roleRef: ClusterRole, default is Undefined, required
         RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
     """
     mixin [

--- a/base/pkg/kusion_models/kube/frontend/rbac/role.k
+++ b/base/pkg/kusion_models/kube/frontend/rbac/role.k
@@ -4,8 +4,8 @@ import base.pkg.kusion_models.kube.mixins
 
 schema Role(common.Metadata):
     """
-    rules : [PolicyRule], default is Undefined, optional
-    Rules holds all the PolicyRules for this ClusterRole
+    rules: [PolicyRule], default is Undefined, optional
+        Rules holds all the PolicyRules for this ClusterRole
     """
     mixin [
         mixins.MetadataMixin

--- a/base/pkg/kusion_models/kube/frontend/rbac/role_binding.k
+++ b/base/pkg/kusion_models/kube/frontend/rbac/role_binding.k
@@ -4,9 +4,9 @@ import base.pkg.kusion_models.kube.mixins
 
 schema RoleBinding(common.Metadata):
     """
-    subjects : [Subject], default is Undefined, optional
+    subjects: [Subject], default is Undefined, optional
         Subjects holds references to the objects the role applies to.
-    roleRef : RoleRef, default is Undefined, required
+    roleRef: RoleRef, default is Undefined, required
         RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
     """
     mixin [

--- a/base/pkg/kusion_models/kube/frontend/resource/resource.k
+++ b/base/pkg/kusion_models/kube/frontend/resource/resource.k
@@ -7,13 +7,13 @@ schema Resource:
 
     Attributes
     ----------
-    cpu: int | Unit, default is 1, required.
+    cpu: int | Unit, default is 1, optional.
         A Container-level attribute.
         CPU, in cores, default 1 core. (500m = .5 cores)
-    memory: Unit, default is 1024Mi, required.
+    memory: Unit, default is 1024Mi, optional.
         A Container-level attribute.
         Memory, in bytes, default 1024Mi. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-    disk: Unit, default is 10Gi, required.
+    disk: Unit, default is 10Gi, optional.
         A Container-level attribute.
         Local disk storage, in bytes, default 10Gi. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 

--- a/base/pkg/kusion_models/kube/frontend/secret/secret.k
+++ b/base/pkg/kusion_models/kube/frontend/secret/secret.k
@@ -8,14 +8,14 @@ schema Secret(common.Metadata):
     Attributes
     ----------
     data: {str:str}, default is Undefined, optional
-         Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. 
-         More info: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data
+        Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. 
+        More info: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data
     stringData: {str:str}, default is Undefined, optional
-         stringData allows specifying non-binary secret data in string form. 
-         More info: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data
+        stringData allows specifying non-binary secret data in string form. 
+        More info: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data
     type: str, default is Undefined, optional
-         Used to facilitate programmatic handling of secret data.
-         More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
+        Used to facilitate programmatic handling of secret data.
+        More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
     
     Examples
     --------

--- a/base/pkg/kusion_models/kube/frontend/server.k
+++ b/base/pkg/kusion_models/kube/frontend/server.k
@@ -14,12 +14,12 @@ schema Server:
 
     Attributes
     ----------
-    workloadType: str, default is "Deployment", required.
+    workloadType: "Deployment" | "StatefulSet", default is "Deployment", required.
         Application workload type, default to 'Deployment'
     replicas: int, default is 1, required.
         Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
-    image: str, default is Undefined, optional.
-        Docker image name.
+    image: str, default is Undefined, required.
+        Container image name.
         More info: https://kubernetes.io/docs/concepts/containers/images
     schedulingStrategy: strategy.SchedulingStrategy, default is Undefined, required.
         SchedulingStrategy represents scheduling strategy.
@@ -34,7 +34,7 @@ schema Server:
     labels: {str:str}, default is Undefined, optional.
         Labels is a map of string keys and values that can be used to organize and categorize (scope and select) objects.
         More info: http://kubernetes.io/docs/user-guide/labels
-    annotations: {str:str}, default is Undefined, optional.
+    annotations: {str:str}, default is Undefined, optional
         Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.
         More info: http://kubernetes.io/docs/user-guide/annotations
     useBuiltInSelector: bool, default is False, optional.
@@ -45,9 +45,9 @@ schema Server:
         PodMetadata is metadata that all persisted resources must have, which includes all objects users must create.
     volumes: [volume.Volume], default is Undefined, optional.
         Volumes represents a named volume and corresponding mounts in containers.
-    needNamespace: bool，default is True, optional.
+    needNamespace: bool, default is True, optional.
         NeedNamespace mark server is namespace scoped or not.
-    enableMonitoring: bool，default is False, optional.
+    enableMonitoring: bool, default is False, optional.
         EnableMonitoring mark server is enable monitor or not.
     configMaps: [configmap.ConfigMap], default is Undefined, optional.
         ConfigMaps is a list of ConfigMap which holds configuration data for server to consume.

--- a/base/pkg/kusion_models/kube/frontend/service/service.k
+++ b/base/pkg/kusion_models/kube/frontend/service/service.k
@@ -27,10 +27,6 @@ schema Service(common.Metadata):
         externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints.
     healthCheckNodePort: int, default is Undefined, optional
         healthCheckNodePort specifies the healthcheck nodePort for the service.
-    internalTrafficPolicy: str, default is Undefined, optional
-        InternalTrafficPolicy specifies if the cluster internal traffic should be routed to all endpoints or node-local endpoints only.
-    ipFamilies: [str], default is Undefined, optional
-        ipFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the "IPv6DualStack" feature gate.
     ipFamilyPolicy: str, default is Undefined, optional
         ipFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.
     loadBalancerIP: str, default is Undefined, optional
@@ -39,16 +35,16 @@ schema Service(common.Metadata):
         If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs.
         This field will be ignored if the cloud-provider does not support the feature.
         More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
-    ports: [ServicePort], default is Undefined, optional
+    ports: [corev1.ServicePort], default is Undefined, optional
         The list of ports that are exposed by this service. 
         More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
     publishNotReadyAddresses: bool, default is Undefined, optional
         publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready.
-    sessionAffinity : str, default is Undefined, optional
+    sessionAffinity: str, default is Undefined, optional
         Supports "ClientIP" and "None". Used to maintain session affinity.
         More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
-    sessionAffinityConfig : SessionAffinityConfig, default is Undefined, optional
-         sessionAffinityConfig contains the configurations of session affinity.
+    sessionAffinityConfig: {str:}, default is Undefined, optional
+        sessionAffinityConfig contains the configurations of session affinity.
 
     Examples
     --------

--- a/base/pkg/kusion_models/kube/frontend/serviceaccount/service_account.k
+++ b/base/pkg/kusion_models/kube/frontend/serviceaccount/service_account.k
@@ -2,7 +2,7 @@ import base.pkg.kusion_models.kube.frontend.common
 
 schema ServiceAccount(common.Metadata):
     """A service account provides an identity for processes that run in a Pod.
-     ServiceAccount binds together:
+    ServiceAccount binds together:
         - a name, understood by users, and perhaps by peripheral systems, for an identity
         - a principal that can be authenticated and authorized
         - a set of secrets

--- a/base/pkg/kusion_models/kube/frontend/sidecar/sidecar.k
+++ b/base/pkg/kusion_models/kube/frontend/sidecar/sidecar.k
@@ -21,12 +21,12 @@ schema Sidecar:
     env: [e.Env], default is Undefined, optional.
         A Container-level attribute.
         List of environment variables in the container.
-    envFrom: [EnvFromSource], default is Undefined, optional
+    envFrom: [e.EnvFromSource], default is Undefined, optional
         A Container-level attribute.
         List of sources to populate environment variables in the container.
-    image: str, default is Undefined, optional
+    image: str, default is Undefined, required
         A Container-level attribute.
-        Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+        Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
     livenessProbe: p.Probe, default is Undefined, optional.
         A Container-level attribute.
         The probe to check whether container is live or not.
@@ -36,19 +36,21 @@ schema Sidecar:
     startupProbe: p.Probe, default is Undefined, optional.
         A Container-level attribute.
         The probe to indicates that the Pod has successfully initialized.
-    resource: str, default is "1<cpu<2,1Gi<memory<2Gi,disk=20Gi", required.
+    resource: str | res.Resource, default is "1<cpu<2,1Gi<memory<2Gi,disk=20Gi", required.
         A Pod-level attribute.
         Sidecar container resource. 
-    lifecycle: Lifecycle, default is Undefined, optional
+    lifecycle: lc.Lifecycle, default is Undefined, optional
         Actions that the management system should take in response to container lifecycle events.
         Cannot be updated.
     workingDir: str, default is Undefined, optional
         Container's working directory. If not specified, the container runtime's default will be used, 
         which might be configured in the container image. Cannot be updated.
-    securityContext: SecurityContext, default is Undefined, optional
+    securityContext: {str:}, default is Undefined, optional
         SecurityContext defines the security options the container should be run with.
         If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
         More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    ports: [cp.ContainerPort], default is Undefined, optional
+        List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
 
     Examples
     --------

--- a/base/pkg/kusion_models/kube/frontend/volume/volume.k
+++ b/base/pkg/kusion_models/kube/frontend/volume/volume.k
@@ -8,7 +8,7 @@ schema Volume:
     name: str, default is Undefined, required.
         Volume's name. Must be a DNS_LABEL and unique within the pod. 
         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-    volumeSource: EmptyDir | Secret | ConfigMap | FlexVolume | HostPath | DownwardAPI, default is Undefined, required.
+    volumeSource: EmptyDir | Secret | ConfigMap | FlexVolume | HostPath | DownwardAPI | CSI, default is Undefined, required.
         VolumeSource represents the location and type of the mounted volume.
     mounts: [Mount], default is Undefined, optional.
         Volumes to mount into the container's filesystem.
@@ -198,7 +198,7 @@ schema CSI:
         A Pod-level attribute.
         Extra command options if any.
     """
-    driver?: str
+    driver: str
     fsType?: str
     readOnly?: bool
     volumeAttributes?: {str:str}


### PR DESCRIPTION
related issue: https://github.com/KusionStack/konfig/issues/59

main changes:
1. schema 注释在与多行注释符号（`"""`）间隔一个空格符，换行后与首个引号对齐
2. 缩进统一为 4 个空格，字段注释格式：`<field name>: <field type>, <default value>, <required or optional>.`
3. 同包的 schema 引用，不需要包名
4. 不同包 schema 引用，使用 import 路径最后一级目录名，有 import 别名，优先使用别名
5. 有字段无注释，无字段有注释
6. 字段类型与注释不匹配 字段属性与注释不匹配