### PR TITLE
workaround kcl lint problem

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,9 +94,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: install-pytest-html
-        run: kclvm -mpip install pytest-html pytest-xdist ruamel.yaml -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com
+        run: |
+          kclvm -mpip install pytest-html pytest-xdist ruamel.yaml -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com
+          # todo: the following script is to workaround "missing kclvm_cli" error, after the problem solved, this can be removed
+          apt -y install wget
+          wget -c https://github.com/KusionStack/KCLVM/releases/download/v0.4.4-beta.1/kclvm-v0.4.4-beta.1-linux-amd64.tar.gz -qO - | tar xz -C ./
       - id: lint-check
         run: |
+          export PATH=$PATH:$(pwd)/kclvm/bin
           kclvm -mpytest -v -n 5 hack/lint_check.py --junitxml ./hack/report/lint-check.xml --html=./hack/report/lint.html
       - id: upload-lint-check-report
         if: always()

--- a/appops/clickhouse-operator/base/base.k
+++ b/appops/clickhouse-operator/base/base.k
@@ -4,7 +4,6 @@ import base.pkg.kusion_models.kube.frontend
 import base.pkg.kusion_models.kube.frontend.configmap
 import base.pkg.kusion_models.kube.frontend.container
 import base.pkg.kusion_models.kube.frontend.container.env as e
-import base.pkg.kusion_models.kube.frontend.container.port as cp
 import base.pkg.kusion_models.kube.frontend.service
 import base.pkg.kusion_models.kube.frontend.serviceaccount as sa
 import base.pkg.kusion_models.kube.frontend.sidecar as s
@@ -129,12 +128,6 @@ appConfiguration: frontend.Server {
         s.Sidecar {
             name = "metrics-exporter"
             image = "altinity/metrics-exporter:0.19.2"
-            ports = [
-                cp.ContainerPort {
-                    name = "metrics"
-                    containerPort = 8888
-                }
-            ]
             resource = ""
         }
     ]

--- a/hack/test_konfig.py
+++ b/hack/test_konfig.py
@@ -45,6 +45,8 @@ def test_konfigs(test_dir):
         kusion_cmd.append(f"{CI_TEST_DIR}/{SETTINGS_FILE}")
         kusion_cmd.append("-Y")
         kusion_cmd.append("kcl.yaml")
+        kusion_cmd.append("-o")
+        kusion_cmd.append("stdout")
     else:
         kusion_cmd.append(f"{MAIN_FILE}")
     process = subprocess.run(


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [X] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

appops/clickhouse-operator/base/base.k

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

This PR is to workaround the kcl lint bug. The sidecar defined in the `base.k` file will be overridden by that defined in the `prod/main.k` file and since kcl lint check works based on the result of the config merge phase, the ContainerPort expression is missing in the lint phase, so kcl lint mistakenly reports an error of "unused import" on the `import base.pkg.kusion_models.kube.frontend.container.port as cp` statement.

The kcl lint bug will be fixed. issue tracked here: todo @He1pa 

To avoid blocking the konfig development (blocked [here](https://github.com/KusionStack/konfig/actions/runs/3845512109/jobs/6549746456#step:5:141)), this PR removes the "unused" code temporarily.

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [X] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [X] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
